### PR TITLE
Fix rendering of some elements not working in IE11

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/package.schema.json",
   "name": "@angular-react/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "ngPackage": {
     "deleteDestPath": true,
     "whitelistedNonPeerDependencies": [

--- a/libs/core/src/lib/renderer/renderer.ts
+++ b/libs/core/src/lib/renderer/renderer.ts
@@ -60,7 +60,7 @@ export class AngularReactRendererFactory extends ɵDomRendererFactory2 {
       const node = this.reactRootNodes[i];
       if (
         !isReactNode(node.parent) &&
-        !document.contains(node.parent) &&
+        !document.body.contains(node.parent) &&
         ReactDOM.unmountComponentAtNode(node.parent)
       ) {
         this.reactRootNodes.splice(i--, 1);


### PR DESCRIPTION
`document.contains` does not exist in IE11.
The cross-browser equivalent, that also supports IE11 is: `document.body.contains` ([see here](https://github.com/skatejs/skatejs/issues/153) for example).

This PR makes this changes.

Note that in most browsers (tested Chrome, Firefox, Edge), `document.contains === document.body.contains`, so no change whatsoever is introduced for non-IE browsers).